### PR TITLE
Use OpenCode free models by default, make API keys optional

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -19,9 +19,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Provider credentials: set any OpenCode-supported provider key as a
-      # repository secret. The action passes them through automatically.
-      # See https://github.com/anomalyco/opencode for the full provider list.
+      # Uses OpenCode's free models by default — no API keys required.
+      # To use a paid provider, set its secret and pass the model input.
       - uses: ./
         with:
           mode: branch
@@ -29,6 +28,3 @@ jobs:
           comment-on-pr: "true"
           upload-sarif: "true"
           fail-on-critical: "true"
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ OpenLens looks for configuration in these locations (last wins):
 {
   "$schema": "https://openlens.dev/config.json",
 
-  "model": "anthropic/claude-sonnet-4-20250514",
+  "model": "opencode/mimo-v2-pro-free",
 
   "agent": {
     "security": {
       "description": "Security vulnerability scanner",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "opencode/mimo-v2-pro-free",
       "prompt": "{file:./agents/security.md}",
       "steps": 5,
       "permission": {
@@ -250,10 +250,10 @@ OpenLens ships with four built-in agents. Each is a markdown file with YAML fron
 
 | Agent           | Focus                      | Default Model                          |
 | --------------- | -------------------------- | -------------------------------------- |
-| `security`      | Vulnerabilities & secrets  | `anthropic/claude-sonnet-4-20250514`   |
-| `bugs`          | Logic errors & edge cases  | `anthropic/claude-sonnet-4-20250514`   |
-| `performance`   | N+1 queries, bottlenecks   | `anthropic/claude-sonnet-4-20250514`   |
-| `style`         | Conventions & dead code    | `anthropic/claude-sonnet-4-20250514`   |
+| `security`      | Vulnerabilities & secrets  | `opencode/mimo-v2-pro-free`   |
+| `bugs`          | Logic errors & edge cases  | `opencode/mimo-v2-pro-free`   |
+| `performance`   | N+1 queries, bottlenecks   | `opencode/mimo-v2-pro-free`   |
+| `style`         | Conventions & dead code    | `opencode/mimo-v2-pro-free`   |
 
 ### Creating Custom Agents
 
@@ -263,7 +263,7 @@ Create a markdown file in `agents/` with YAML frontmatter:
 ---
 description: Accessibility checker
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: opencode/mimo-v2-pro-free
 steps: 5
 permission:
   read: allow
@@ -331,7 +331,7 @@ openlens agent create a11y --description "Accessibility checker"
 | -------------- | -------------------------------------- | ------------- | ------------------------------------ |
 | `description`  | string                                 | —             | Human-readable description           |
 | `mode`         | `"primary"` \| `"subagent"` \| `"all"` | `"subagent"` | When the agent can run               |
-| `model`        | string                                 | Global model  | Provider/model-id (e.g. `anthropic/claude-sonnet-4-20250514`) |
+| `model`        | string                                 | Global model  | Provider/model-id (e.g. `opencode/mimo-v2-pro-free`) |
 | `prompt`       | string                                 | —             | Inline text or `{file:./path.md}`    |
 | `steps`        | number                                 | `5`           | Max agentic loop iterations          |
 | `temperature`  | number                                 | —             | Sampling temperature (0–1)           |
@@ -379,7 +379,7 @@ openlens doctor                 Check environment and configuration
 | Flag               | Description                                      |
 | ------------------ | ------------------------------------------------ |
 | `--description`    | Agent description                                |
-| `--model`          | Model to use (e.g. `anthropic/claude-sonnet-4-20250514`) |
+| `--model`          | Model to use (e.g. `opencode/mimo-v2-pro-free`) |
 | `--steps`          | Max agentic loop iterations (default: 5)         |
 
 ### `openlens agent test`

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -213,13 +213,13 @@ Both `.json` and `.jsonc` (JSON with comments) are supported.
 {
   "$schema": "https://openlens.dev/config.json",
 
-  "model": "anthropic/claude-sonnet-4-20250514",
+  "model": "opencode/mimo-v2-pro-free",
 
   "agent": {
     "security": {
       "description": "Security vulnerability scanner",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "opencode/mimo-v2-pro-free",
       "prompt": "{file:./agents/security.md}",
       "steps": 5,
       "disable": false,
@@ -455,7 +455,7 @@ Here's a complete custom agent example following this pattern:
 ---
 description: Accessibility checker
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: opencode/mimo-v2-pro-free
 steps: 5
 permission:
   read: allow
@@ -815,7 +815,7 @@ Generate a new agent scaffold.
 | Flag              | Description                                          |
 | ----------------- | ---------------------------------------------------- |
 | `--description`   | Agent description                                    |
-| `--model`         | Model override (e.g. `anthropic/claude-sonnet-4-20250514`) |
+| `--model`         | Model override (e.g. `opencode/mimo-v2-pro-free`) |
 | `--steps`         | Max agentic loop iterations (default: 5)             |
 
 ```bash
@@ -1149,7 +1149,7 @@ jobs:
 | `upload-sarif`     | `true`     | Upload SARIF to GitHub Code Scanning           |
 | `fail-on-critical` | `true`     | Fail workflow on critical issues               |
 | `comment-on-pr`    | `false`    | Post review results as a PR comment            |
-| `model`            |            | Override model (e.g. `anthropic/claude-sonnet-4-20250514`) |
+| `model`            |            | Override model (e.g. `opencode/mimo-v2-pro-free`) |
 | `anthropic-api-key`|            | Anthropic API key (optional — or set env var)  |
 | `openai-api-key`   |            | OpenAI API key (optional — or set env var)     |
 

--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,13 @@ inputs:
     required: false
     default: "true"
   model:
-    description: "Override model (e.g. anthropic/claude-sonnet-4-20250514)"
+    description: "Override model (default: opencode/mimo-v2-pro-free). Use any OpenCode-supported model."
     required: false
   anthropic-api-key:
-    description: "Anthropic API key (or set ANTHROPIC_API_KEY env var)"
+    description: "Anthropic API key — only needed when using Anthropic models"
     required: false
   openai-api-key:
-    description: "OpenAI API key (or set OPENAI_API_KEY env var)"
+    description: "OpenAI API key — only needed when using OpenAI models"
     required: false
   comment-on-pr:
     description: "Post review results as a PR comment (pull_request events only)"
@@ -90,9 +90,9 @@ runs:
       env:
         # CI detection
         CI: "true"
-        # API keys — prefer explicit inputs, fall back to env vars
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key || env.ANTHROPIC_API_KEY }}
-        OPENAI_API_KEY: ${{ inputs.openai-api-key || env.OPENAI_API_KEY }}
+        # API keys — only needed when using paid provider models
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key || env.ANTHROPIC_API_KEY || '' }}
+        OPENAI_API_KEY: ${{ inputs.openai-api-key || env.OPENAI_API_KEY || '' }}
         # OpenLens config overrides
         OPENLENS_MODE: ${{ inputs.mode }}
         OPENLENS_AGENTS: ${{ inputs.agents }}

--- a/agents/bugs.md
+++ b/agents/bugs.md
@@ -1,7 +1,7 @@
 ---
 description: Bug and logic error detector
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: opencode/mimo-v2-pro-free
 steps: 5
 permission:
   read: allow

--- a/agents/performance.md
+++ b/agents/performance.md
@@ -1,7 +1,7 @@
 ---
 description: Performance issue finder
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: opencode/mimo-v2-pro-free
 steps: 5
 permission:
   read: allow

--- a/agents/security.md
+++ b/agents/security.md
@@ -1,7 +1,7 @@
 ---
 description: Security vulnerability scanner
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: opencode/mimo-v2-pro-free
 steps: 5
 permission:
   read: allow

--- a/agents/style.md
+++ b/agents/style.md
@@ -1,7 +1,7 @@
 ---
 description: Style and convention checker
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: opencode/mimo-v2-pro-free
 steps: 5
 permission:
   read: allow

--- a/openlens.json.example
+++ b/openlens.json.example
@@ -1,13 +1,13 @@
 {
   "$schema": "https://openlens.dev/config.json",
 
-  "model": "anthropic/claude-sonnet-4-20250514",
+  "model": "opencode/mimo-v2-pro-free",
 
   "agent": {
     "security": {
       "description": "Security vulnerability scanner",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "opencode/mimo-v2-pro-free",
       "prompt": "{file:./agents/security.md}",
       "steps": 5,
       "permission": {
@@ -30,14 +30,12 @@
     "performance": {
       "description": "Performance issue finder",
       "mode": "subagent",
-      "model": "openai/gpt-4o",
       "prompt": "{file:./agents/performance.md}",
       "steps": 5
     },
     "style": {
       "description": "Style and convention checker",
       "mode": "subagent",
-      "model": "anthropic/claude-haiku-4-5-20251001",
       "prompt": "{file:./agents/style.md}",
       "steps": 3
     }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -39,7 +39,7 @@ export const AgentConfigSchema = z.object({
 
 export const ConfigSchema = z.object({
   $schema: z.string().optional(),
-  model: z.string().default("anthropic/claude-sonnet-4-20250514"),
+  model: z.string().default("opencode/mimo-v2-pro-free"),
   agent: z.record(z.string(), AgentConfigSchema).default({}),
   // Global permissions (agents inherit these, can override)
   permission: z.record(z.string(), PermissionValueSchema).optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ yargs(hideBin(process.argv))
         .option("model", {
           alias: "m",
           type: "string",
-          describe: "Override model for all agents (e.g. anthropic/claude-sonnet-4-20250514)",
+          describe: "Override model for all agents (e.g. opencode/mimo-v2-pro-free)",
         })
         .option("format", {
           alias: "f",
@@ -299,7 +299,7 @@ yargs(hideBin(process.argv))
             })
             .option("model", {
               type: "string",
-              describe: "Model to use (e.g. anthropic/claude-sonnet-4-20250514)",
+              describe: "Model to use (e.g. opencode/mimo-v2-pro-free)",
             })
             .option("steps", {
               type: "number",
@@ -319,7 +319,7 @@ yargs(hideBin(process.argv))
           const agentPath = path.join(agentsDir, `${name}.md`)
 
           const description = argv.description || `${name} code reviewer`
-          const model = argv.model || "anthropic/claude-sonnet-4-20250514"
+          const model = argv.model || "opencode/mimo-v2-pro-free"
           const steps = argv.steps || 5
 
           // Generate agent prompt file with frontmatter
@@ -447,7 +447,7 @@ If no issues found, return \`[]\`
             .option("model", {
               alias: "m",
               type: "string",
-              describe: "Override model (e.g. anthropic/claude-sonnet-4-20250514)",
+              describe: "Override model (e.g. opencode/mimo-v2-pro-free)",
             })
             .option("verbose", {
               type: "boolean",
@@ -765,7 +765,7 @@ If no issues found, return \`[]\`
       } catch {
         const defaultConfig = {
           $schema: "https://openlens.dev/config.json",
-          model: "anthropic/claude-sonnet-4-20250514",
+          model: "opencode/mimo-v2-pro-free",
           agent: {
             security: {
               description: "Security vulnerability scanner",
@@ -918,22 +918,17 @@ If no issues found, return \`[]\`
         hasErrors = true
       }
 
-      // 3. Check API keys
+      // 3. Check API keys (optional — free models work without them)
       const hasAnthropic = !!process.env.ANTHROPIC_API_KEY
       const hasOpenAI = !!process.env.OPENAI_API_KEY
       if (hasAnthropic) {
         console.log(`  ${G}✓${R} ANTHROPIC_API_KEY  ${D}set${R}`)
-      } else {
-        console.log(`  ${YELLOW}!${R} ANTHROPIC_API_KEY  ${D}not set${R}`)
       }
       if (hasOpenAI) {
         console.log(`  ${G}✓${R} OPENAI_API_KEY  ${D}set${R}`)
-      } else {
-        console.log(`  ${D}○${R} OPENAI_API_KEY  ${D}not set${R}`)
       }
       if (!hasAnthropic && !hasOpenAI) {
-        console.log(`    ${YELLOW}No API keys found. Set at least one provider key.${R}`)
-        hasErrors = true
+        console.log(`  ${D}○${R} API keys  ${D}not set (optional — free models available)${R}`)
       }
 
       // 4. Check config

--- a/src/session/review.ts
+++ b/src/session/review.ts
@@ -17,7 +17,7 @@ import path from "path"
 
 function parseModel(model: string): { providerID: string; modelID: string } {
   const slash = model.indexOf("/")
-  if (slash === -1) return { providerID: "anthropic", modelID: model }
+  if (slash === -1) return { providerID: "opencode", modelID: model }
   return {
     providerID: model.slice(0, slash),
     modelID: model.slice(slash + 1),

--- a/test/e2e/doctor.test.ts
+++ b/test/e2e/doctor.test.ts
@@ -50,7 +50,7 @@ describe("openlens doctor", () => {
   test("validates config file", TIMEOUT, () => {
     tmpDir = createTempGitRepo()
     writeConfig(tmpDir, {
-      model: "anthropic/claude-sonnet-4-20250514",
+      model: "opencode/mimo-v2-pro-free",
       agent: {
         security: { description: "Scanner" },
       },
@@ -59,7 +59,7 @@ describe("openlens doctor", () => {
     const result = run(["doctor"], tmpDir)
 
     expect(result.stdout).toContain("config")
-    expect(result.stdout).toContain("anthropic/claude-sonnet-4-20250514")
+    expect(result.stdout).toContain("opencode/mimo-v2-pro-free")
   })
 
   test("reports loaded agents", TIMEOUT, () => {

--- a/test/e2e/init.test.ts
+++ b/test/e2e/init.test.ts
@@ -23,7 +23,7 @@ describe("openlens init", () => {
 
     const config = JSON.parse(fs.readFileSync(configPath, "utf-8"))
     expect(config.$schema).toBeDefined()
-    expect(config.model).toContain("anthropic/")
+    expect(config.model).toContain("opencode/")
     expect(config.agent).toBeDefined()
     expect(config.agent.security).toBeDefined()
     expect(config.agent.bugs).toBeDefined()

--- a/test/e2e/serve.test.ts
+++ b/test/e2e/serve.test.ts
@@ -132,7 +132,7 @@ describe("openlens serve", () => {
   test("GET /config returns config", TIMEOUT, async () => {
     tmpDir = createTempGitRepo()
     writeConfig(tmpDir, {
-      model: "anthropic/claude-sonnet-4-20250514",
+      model: "opencode/mimo-v2-pro-free",
       server: { port: 14099, hostname: "localhost" },
     })
 
@@ -140,7 +140,7 @@ describe("openlens serve", () => {
     serverProc = proc
 
     const config = await fetchJson(`${url}/config`)
-    expect(config.model).toBe("anthropic/claude-sonnet-4-20250514")
+    expect(config.model).toBe("opencode/mimo-v2-pro-free")
     expect(config.server).toBeDefined()
     expect(config.review).toBeDefined()
   })

--- a/test/unit/config-load.test.ts
+++ b/test/unit/config-load.test.ts
@@ -22,7 +22,7 @@ describe("loadConfig", () => {
 
   test("returns valid config with defaults when no config file exists", async () => {
     const config = await loadConfig(tmpDir)
-    expect(config.model).toBe("anthropic/claude-sonnet-4-20250514")
+    expect(config.model).toBe("opencode/mimo-v2-pro-free")
     expect(config.server.port).toBe(4096)
     expect(config.review.defaultMode).toBe("staged")
   })

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -4,7 +4,7 @@ import { ConfigSchema, AgentConfigSchema } from "../../src/config/schema.js"
 describe("ConfigSchema", () => {
   test("parses minimal config with defaults", () => {
     const config = ConfigSchema.parse({})
-    expect(config.model).toBe("anthropic/claude-sonnet-4-20250514")
+    expect(config.model).toBe("opencode/mimo-v2-pro-free")
     expect(config.server.port).toBe(4096)
     expect(config.server.hostname).toBe("localhost")
     expect(config.review.defaultMode).toBe("staged")

--- a/test/unit/review-helpers.test.ts
+++ b/test/unit/review-helpers.test.ts
@@ -44,7 +44,7 @@ function getAllowedToolNames(permission: Record<string, any>): string[] {
 // --- parseModel ---
 function parseModel(model: string): { providerID: string; modelID: string } {
   const slash = model.indexOf("/")
-  if (slash === -1) return { providerID: "anthropic", modelID: model }
+  if (slash === -1) return { providerID: "opencode", modelID: model }
   return {
     providerID: model.slice(0, slash),
     modelID: model.slice(slash + 1),
@@ -173,10 +173,10 @@ describe("parseModel", () => {
     })
   })
 
-  test("defaults to anthropic when no slash", () => {
-    expect(parseModel("claude-sonnet-4-20250514")).toEqual({
-      providerID: "anthropic",
-      modelID: "claude-sonnet-4-20250514",
+  test("defaults to opencode when no slash", () => {
+    expect(parseModel("mimo-v2-pro-free")).toEqual({
+      providerID: "opencode",
+      modelID: "mimo-v2-pro-free",
     })
   })
 

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -55,7 +55,7 @@ describe("createServer", () => {
     const app = createServer(baseConfig())
     const res = await app.request("/config")
     const body = await res.json()
-    expect(body.model).toBe("anthropic/claude-sonnet-4-20250514")
+    expect(body.model).toBe("opencode/mimo-v2-pro-free")
     expect(body.review.defaultMode).toBe("staged")
   })
 


### PR DESCRIPTION
Switch default model from anthropic/claude-sonnet-4-20250514 to opencode/mimo-v2-pro-free across all agents, config, docs, and tests. OpenCode ships free models that require no API key, so the CI workflow no longer needs provider secrets. API keys remain supported as optional overrides for paid models.

https://claude.ai/code/session_01JrAEg7Q3kyE8ooYrxCFdJ7